### PR TITLE
feat(cdk8s): the App root construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ applications and reusable abstractions using familiar programming languages and
 rich object-oriented APIs.
 
 - [Getting Started](#getting-started)
+- [API Reference](#api-reference)
 - [Examples](#examples)
 - [Getting Help](#getting-help)
 - [Contributions](#contributions)
@@ -110,8 +111,8 @@ $ yarn watch
 At this point, if you open `main.ts` you will see something like this:
 
 ```ts
-import { App, Construct } from '@aws-cdk/core';
-import { Chart } from '@awslabs/cdk8s';
+import { Construct } from '@aws-cdk/core';
+import { Chart, App } from '@awslabs/cdk8s';
 
 class MyChart extends Chart {
   constructor(scope: Construct, name: string) {
@@ -121,7 +122,7 @@ class MyChart extends Chart {
   }
 }
 
-const app = new App({ outdir: 'dist' });
+const app = new App();
 new MyChart(app, 'hello');
 app.synth();
 ```
@@ -164,8 +165,8 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
 [hello-kubernetes](https://github.com/paulbouwer/hello-kubernetes) project.
 
 ```ts
-import { App, Construct } from '@aws-cdk/core';
-import { Chart } from '@awslabs/cdk8s';
+import { Construct } from '@aws-cdk/core';
+import { App, Chart } from '@awslabs/cdk8s';
 
 // import generated constructs
 import { Service, IntOrString } from './.gen/service-v1';
@@ -208,7 +209,7 @@ class MyChart extends Chart {
   }
 }
 
-const app = new App({ outdir: 'dist' });
+const app = new App();
 new MyChart(app, 'hello');
 app.synth();
 ```
@@ -398,6 +399,18 @@ export class MyChart extends Chart {
 As you can see, we now add define `WebService` constructs inside our chart: one
 that runs the `paulbouwer/hello-kubernetes` image and one with an installation
 of [ghost](https://hub.docker.com/_/ghost/)
+
+
+
+## API Reference
+
+### Testing
+
+cdk8s bundles a set of test utilities under the `Testing` class:
+
+* `Testing.app()` returns an `App` object bound to a temporary output directory.
+* `Testing.synth(chart)` returns the Kubernetes manifest synthesized from a
+  chart.
 
 ## Examples
 

--- a/examples/hello/hello.test.ts
+++ b/examples/hello/hello.test.ts
@@ -1,9 +1,8 @@
-import { App } from '@aws-cdk/core';
 import { HelloKube } from './hello';
 import { Testing } from '@awslabs/cdk8s';
 
 test('snapshot', () => {
-  const app = new App();
+  const app = Testing.app();
   const chart = new HelloKube(app, 'hello');
 
   expect(Testing.synth(chart)).toMatchSnapshot();

--- a/examples/podinfo/examples/app-example.ts
+++ b/examples/podinfo/examples/app-example.ts
@@ -1,5 +1,5 @@
-import { App, Construct } from "@aws-cdk/core";
-import { Chart } from "@awslabs/cdk8s";
+import { Construct } from "@aws-cdk/core";
+import { App, Chart } from "@awslabs/cdk8s";
 import { Deployment, Service } from "../lib";
 import { PodinfoContainer } from "./podinfo";
 
@@ -28,6 +28,6 @@ class MyChart extends Chart {
   }
 }
 
-const app = new App({ outdir: 'cdk.out' });
+const app = new App();
 new MyChart(app, 'podinfo');
 app.synth();

--- a/examples/web-service/index.ts
+++ b/examples/web-service/index.ts
@@ -1,5 +1,5 @@
-import { App, Construct } from '@aws-cdk/core';
-import { Chart } from '@awslabs/cdk8s';
+import { Construct } from '@aws-cdk/core';
+import { App, Chart } from '@awslabs/cdk8s';
 import { WebService } from './web-service';
 
 class MyChart extends Chart {
@@ -18,6 +18,6 @@ class MyChart extends Chart {
   }
 }
 
-const app = new App({ outdir: 'cdk.out' });
+const app = new App();
 new MyChart(app, 'web-service-example');
 app.synth();

--- a/packages/cdk8s-cli/templates/typescript-app/main.ts
+++ b/packages/cdk8s-cli/templates/typescript-app/main.ts
@@ -1,5 +1,5 @@
-import { App, Construct } from '@aws-cdk/core';
-import { Chart } from '@awslabs/cdk8s';
+import { Construct } from '@aws-cdk/core';
+import { App, Chart } from '@awslabs/cdk8s';
 
 class MyChart extends Chart {
   constructor(scope: Construct, name: string) {
@@ -9,6 +9,6 @@ class MyChart extends Chart {
   }
 }
 
-const app = new App({ outdir: 'dist' });
+const app = new App();
 new MyChart(app, '{{ $base }}');
 app.synth();

--- a/packages/cdk8s/lib/app.ts
+++ b/packages/cdk8s/lib/app.ts
@@ -1,0 +1,50 @@
+import { Construct, ConstructNode } from '@aws-cdk/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface AppOptions {
+  /**
+   * The directory to output Kubernetes manifests.
+   * 
+   * @default "dist"
+   */
+  readonly outdir?: string;
+}
+
+/**
+ * Represents a cdk8s application.
+ */
+export class App extends Construct {
+  /**
+   * The output directory into which manifests will be synthesized.
+   */
+  public readonly outdir: string;
+
+  /**
+   * Defines an app
+   * @param options configuration options
+   */
+  constructor(options: AppOptions = { }) {
+    super(undefined as any, '');
+    this.outdir = options.outdir ?? 'dist';
+  }
+
+  /**
+   * Synthesizes all manifests to the output directory
+   */
+  public synth(): void {
+    ConstructNode.synth(this.node, {
+      outdir: this.outdir
+    });
+
+    // remove manifest.json and cdk.out
+    rm(path.join(this.outdir, 'manifest.json'));
+    rm(path.join(this.outdir, 'cdk.out'));
+  }
+}
+
+function rm(filePath: string) {
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+}

--- a/packages/cdk8s/lib/index.ts
+++ b/packages/cdk8s/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './api-object';
 export * from './chart';
 export * from './testing';
+export * from './app';

--- a/packages/cdk8s/lib/testing.ts
+++ b/packages/cdk8s/lib/testing.ts
@@ -1,7 +1,7 @@
 import fs = require('fs');
 import path = require('path');
-import { Chart } from '../lib';
-import { App } from '@aws-cdk/core';
+import os = require('os');
+import { App, Chart } from '../lib';
 import * as YAML from 'yaml';
 
 /**
@@ -9,12 +9,22 @@ import * as YAML from 'yaml';
  */
 export class Testing {
   /**
+   * Returns an app for testing with the following properties:
+   * - Output directory is a temp dir.
+   */
+  public static app() {
+    const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s.outdir.'));
+    return new App({ outdir });
+  }
+
+  /**
    * Returns the Kubernetes manifest synthesized from this chart.
    */
   public static synth(chart: Chart) {
     const app = chart.node.root as App;
-    const assembly = app.synth();
-    const filePath = path.join(assembly.directory, chart.manifestFile);
+    app.synth();
+    
+    const filePath = path.join(app.outdir, chart.manifestFile);
     return YAML.parseAllDocuments(fs.readFileSync(filePath, 'utf-8')).map((doc: any) => doc.toJSON());
   }
 

--- a/packages/cdk8s/test/api-object.test.ts
+++ b/packages/cdk8s/test/api-object.test.ts
@@ -1,8 +1,8 @@
 import { ApiObject, Chart, Testing } from '../lib';
-import { App, Construct } from '@aws-cdk/core';
+import { Construct } from '@aws-cdk/core';
 
 test('minimal configuration', () => {
-  const app = new App();
+  const app = Testing.app();
   const stack = new Chart(app, 'test');
 
   new ApiObject(stack, 'my-resource', {
@@ -15,7 +15,7 @@ test('minimal configuration', () => {
 
 test('synthesized resource name is based on path', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const stack = new Chart(app, 'test');
   new ApiObject(stack, 'my-resource', {
     apiVersion: 'v1',
@@ -36,7 +36,7 @@ test('synthesized resource name is based on path', () => {
 
 test('if name is explicitly specified it will be respected', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const stack = new Chart(app, 'test');
 
   // WHEN
@@ -54,7 +54,7 @@ test('if name is explicitly specified it will be respected', () => {
 
 test('"spec" is synthesized as-is', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const stack = new Chart(app, 'test');
 
   // WHEN
@@ -75,7 +75,7 @@ test('"spec" is synthesized as-is', () => {
 
 test('"data" can be used to specify resource data', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const stack = new Chart(app, 'test');
 
   // WHEN
@@ -99,7 +99,7 @@ test('object naming logic can be overridden at the chart level', () => {
   }
 
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const chart = new MyChart(app, 'my-chart');
 
   // WHEN

--- a/packages/cdk8s/test/app.test.ts
+++ b/packages/cdk8s/test/app.test.ts
@@ -1,0 +1,29 @@
+import { Testing, Chart } from '../lib';
+import * as fs from 'fs';
+
+test('empty app emits no files', () => {
+  // GIVEN
+  const app = Testing.app();
+
+  // WHEN
+  app.synth();
+
+  // THEN
+  expect(fs.readdirSync(app.outdir)).toHaveLength(0);
+});
+
+test('app with two charts', () => {
+  // GIVEN
+  const app = Testing.app();
+
+  // WHEN
+  new Chart(app, 'chart1');
+  new Chart(app, 'chart2');
+  app.synth();
+
+  // THEN
+  expect(fs.readdirSync(app.outdir)).toEqual([
+    'chart1.k8s.yaml',
+    'chart2.k8s.yaml'
+  ]);
+});

--- a/packages/cdk8s/test/chart.test.ts
+++ b/packages/cdk8s/test/chart.test.ts
@@ -1,9 +1,9 @@
 import { Chart, ApiObject, Testing } from '../lib';
-import { App, Construct, Lazy } from '@aws-cdk/core';
+import { Construct, Lazy } from '@aws-cdk/core';
 
 test('empty stack', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
 
   // WHEN
   const chart = new Chart(app, 'empty');
@@ -14,7 +14,7 @@ test('empty stack', () => {
 
 test('output includes all synthesized resources', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const chart = new Chart(app, 'test');
 
   // WHEN
@@ -34,7 +34,7 @@ test('output includes all synthesized resources', () => {
 
 test('tokens are resolved during synth', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const chart = new Chart(app, 'test');
 
   // WHEN
@@ -53,7 +53,7 @@ test('tokens are resolved during synth', () => {
 
 test('Chart.of(node) returns the first chart in which a node is defined', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   
   // WHEN
   const chart = new Chart(app, 'MyFirst');
@@ -72,7 +72,7 @@ test('Chart.of(node) returns the first chart in which a node is defined', () => 
 
 test('Chart.of(node) fails when there is no chart in the tree', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const child = new Construct(app, 'MyConstruct');
 
   // WHEN

--- a/packages/cdk8s/test/tokens.test.ts
+++ b/packages/cdk8s/test/tokens.test.ts
@@ -1,9 +1,10 @@
-import { App, Lazy } from "@aws-cdk/core";
+import { Lazy } from "@aws-cdk/core";
 import { resolve } from "../lib/_tokens";
+import { Testing } from '../lib';
 
 test('lazy', () => {
   // GIVEN
-  const app = new App();
+  const app = Testing.app();
   const hello = {
     number: Lazy.numberValue({ produce: () => 1234 }),
     string: Lazy.stringValue({ produce: () => 'hello' }),


### PR DESCRIPTION
Expose an `App` construct directly from cdk8s so we don’t have to use the one from @aws-cdk/core. 

This one is simpler and defaults the output directory to `dist`, which removes boilerplate. 

It will also give us more control over the cdk8s-specific experience, and reduces the dependency surface in @aws-cdk/core.

To facilitate testing, `Testing.app()` can be used to return an App object with a temporary output directory.

Added a README section about testing.
