### PR TITLE
fix(lib): Update imports so they will work with TS esModuleInterop

### DIFF
--- a/packages/cdk8s-plus-17/src/config-map.ts
+++ b/packages/cdk8s-plus-17/src/config-map.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as cdk8s from 'cdk8s';
 import { Construct } from 'constructs';
-import * as minimatch from 'minimatch';
+import minimatch = require('minimatch');
 import { ResourceProps, Resource, IResource } from './base';
 import * as k8s from './imports/k8s';
 import { undefinedIfEmpty } from './utils';

--- a/packages/cdk8s/src/api-object.ts
+++ b/packages/cdk8s/src/api-object.ts
@@ -1,5 +1,5 @@
 import { Construct, IConstruct, Node } from 'constructs';
-import * as stringify from 'json-stable-stringify';
+import stringify = require('json-stable-stringify');
 import { resolve } from './_resolve';
 import { sanitizeValue } from './_util';
 import { Chart } from './chart';


### PR DESCRIPTION
The imports as previously defined would run into an error when imported by projects that use the current tsconfig.json default of true for compilerOptions esModuleInterop.

```
Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
```

This changes the code to use a require and thus allow usage with projects using interop.

I suggest considering enabling esModuleInterop for the project as a whole as this is the direction Typescript has gone with their defaults.  Although I confess this is not a place I have a strong understanding.  I am going to include a few links that I ran across though in my investigation of why this wasn't working for me.  This could help others decide if it would make sense.  In any case, changing these two imports allows the code to work for people using interop.

References:  (sorry to reference stackoverflow, but it was the most clear summaries I could find)

   * TS 2.7 Change: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop
   * Example handling the same issue: https://stackoverflow.com/questions/49256040/a-namespace-style-import-cannot-be-called-or-constructed-and-will-cause-a-failu
   * Good answer with details: https://stackoverflow.com/a/56348146/205103

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
