### PR TITLE
feat: Allow configuration of how YAML output is divided into files

### DIFF
--- a/packages/cdk8s/API.md
+++ b/packages/cdk8s/API.md
@@ -49,6 +49,7 @@ Name|Description
 Name|Description
 ----|-----------
 [SizeRoundingBehavior](#cdk8s-sizeroundingbehavior)|Rounding behaviour when converting between units of `Size`.
+[YamlOutputType](#cdk8s-yamloutputtype)|The way to divide YAML output into files.
 
 
 
@@ -274,6 +275,7 @@ new App(props?: AppProps)
 
 * **props** (<code>[AppProps](#cdk8s-appprops)</code>)  configuration options.
   * **outdir** (<code>string</code>)  The directory to output Kubernetes manifests. __*Default*__: CDK8S_OUTDIR if defined, otherwise "dist"
+  * **yamlOutputType** (<code>[YamlOutputType](#cdk8s-yamloutputtype)</code>)  How to divide the YAML output into files. __*Default*__: YamlOutputType.FILE_PER_CHART
 
 
 
@@ -283,6 +285,7 @@ new App(props?: AppProps)
 Name | Type | Description 
 -----|------|-------------
 **outdir**🔹 | <code>string</code> | The output directory into which manifests will be synthesized.
+**yamlOutputType**🔹 | <code>[YamlOutputType](#cdk8s-yamloutputtype)</code> | How to divide the YAML output into files.
 
 ### Methods
 
@@ -1186,14 +1189,17 @@ Testing utilities for cdk8s applications.
 ### Methods
 
 
-#### *static* app()🔹 <a id="cdk8s-testing-app"></a>
+#### *static* app(props?)🔹 <a id="cdk8s-testing-app"></a>
 
 Returns an app for testing with the following properties: - Output directory is a temp dir.
 
 ```ts
-static app(): App
+static app(props?: AppProps): App
 ```
 
+* **props** (<code>[AppProps](#cdk8s-appprops)</code>)  *No description*
+  * **outdir** (<code>string</code>)  The directory to output Kubernetes manifests. __*Default*__: CDK8S_OUTDIR if defined, otherwise "dist"
+  * **yamlOutputType** (<code>[YamlOutputType](#cdk8s-yamloutputtype)</code>)  How to divide the YAML output into files. __*Default*__: YamlOutputType.FILE_PER_CHART
 
 __Returns__:
 * <code>[App](#cdk8s-app)</code>
@@ -1318,6 +1324,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **outdir**?🔹 | <code>string</code> | The directory to output Kubernetes manifests.<br/>__*Default*__: CDK8S_OUTDIR if defined, otherwise "dist"
+**yamlOutputType**?🔹 | <code>[YamlOutputType](#cdk8s-yamloutputtype)</code> | How to divide the YAML output into files.<br/>__*Default*__: YamlOutputType.FILE_PER_CHART
 
 
 
@@ -1451,5 +1458,16 @@ Name | Description
 **FAIL** 🔹|Fail the conversion if the result is not an integer.
 **FLOOR** 🔹|If the result is not an integer, round it to the closest integer less than the result.
 **NONE** 🔹|Don't round.
+
+
+## enum YamlOutputType 🔹 <a id="cdk8s-yamloutputtype"></a>
+
+The way to divide YAML output into files.
+
+Name | Description
+-----|-----
+**FILE_PER_APP** 🔹|
+**FILE_PER_CHART** 🔹|
+**FILE_PER_RESOURCE** 🔹|
 
 

--- a/packages/cdk8s/src/testing.ts
+++ b/packages/cdk8s/src/testing.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { App } from './app';
+import { App, AppProps } from './app';
 import { Chart } from './chart';
 
 /**
@@ -12,9 +12,14 @@ export class Testing {
    * Returns an app for testing with the following properties:
    * - Output directory is a temp dir.
    */
-  public static app() {
-    const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s.outdir.'));
-    return new App({ outdir });
+  public static app(props?: AppProps) {
+    let outdir: string;
+    if (props) {
+      outdir = props.outdir ? props.outdir : fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s.outdir.'));
+    } else {
+      outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk8s.outdir.'));
+    }
+    return new App({ outdir, ...props });
   }
 
   /**

--- a/packages/cdk8s/test/app.test.ts
+++ b/packages/cdk8s/test/app.test.ts
@@ -2,85 +2,149 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { Node, Construct } from 'constructs';
-import { Testing, Chart, App, ApiObject } from '../src';
+import { Testing, Chart, App, ApiObject, AppProps, YamlOutputType } from '../src';
+
 
 test('empty app emits no files', () => {
-  // GIVEN
-  const app = Testing.app();
+  const outputTypes: Array<AppProps> = [
+    { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+    { yamlOutputType: YamlOutputType.FILE_PER_APP },
+    { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+  ];
+  for (const props of outputTypes) {
+    // GIVEN
+    const app = Testing.app(props);
 
-  // WHEN
-  app.synth();
+    // WHEN
+    app.synth();
 
-  // THEN
-  expect(fs.readdirSync(app.outdir)).toHaveLength(0);
+    // THEN
+    expect(fs.readdirSync(app.outdir)).toHaveLength(0);
+  }
 });
 
 test('app with two charts', () => {
-  // GIVEN
-  const app = Testing.app();
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+      result: ['chart1.k8s.yaml', 'chart2.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP },
+      result: [],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [],
+    },
+  ];
+  for (const testSpec of testSpecs) {
+    // GIVEN
+    const app = Testing.app(testSpec.props);
 
-  // WHEN
-  new Chart(app, 'chart1');
-  new Chart(app, 'chart2');
-  app.synth();
+    // WHEN
+    new Chart(app, 'chart1');
+    new Chart(app, 'chart2');
+    app.synth();
 
-  // THEN
-  expect(fs.readdirSync(app.outdir)).toEqual([
-    'chart1.k8s.yaml',
-    'chart2.k8s.yaml',
-  ]);
+    // THEN
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
 });
 
 test('app with charts directly dependant', () => {
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+      result: [
+        '0000-chart3.k8s.yaml',
+        '0001-chart2.k8s.yaml',
+        '0002-chart1.k8s.yaml',
+      ],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP },
+      result: [],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [],
+    },
+  ];
 
-  // GIVEN
-  const app = Testing.app();
+  for (const testSpec of testSpecs) {
+    // GIVEN
+    const app = Testing.app(testSpec.props);
 
-  // WHEN
-  const chart1 = new Chart(app, 'chart1');
-  const chart2 = new Chart(app, 'chart2');
-  const chart3 = new Chart(app, 'chart3');
+    // WHEN
+    const chart1 = new Chart(app, 'chart1');
+    const chart2 = new Chart(app, 'chart2');
+    const chart3 = new Chart(app, 'chart3');
 
-  Node.of(chart1).addDependency(chart2);
-  Node.of(chart2).addDependency(chart3);
+    Node.of(chart1).addDependency(chart2);
+    Node.of(chart2).addDependency(chart3);
 
-  app.synth();
+    app.synth();
 
-  // THEN
-  expect(fs.readdirSync(app.outdir)).toEqual([
-    '0000-chart3.k8s.yaml',
-    '0001-chart2.k8s.yaml',
-    '0002-chart1.k8s.yaml',
-  ]);
-
+    // THEN
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
 });
 
 test('app with charts indirectly dependant', () => {
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+      result: [
+        '0000-chart3.k8s.yaml',
+        '0001-chart2.k8s.yaml',
+        '0002-chart1.k8s.yaml',
+      ],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP },
+      result: ['app.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [
+        'v1.Kind1.chart1-obj1-c818e77f.k8s.yaml',
+        'v1.Kind2.chart2-obj2-c8636f20.k8s.yaml',
+        'v1.Kind3.chart3-obj3-c8abbfb5.k8s.yaml',
+      ],
+    },
+  ];
 
-  // GIVEN
-  const app = Testing.app();
+  for (const testSpec of testSpecs) {
+    // GIVEN
+    const app = Testing.app(testSpec.props);
 
-  // WHEN
-  const chart1 = new Chart(app, 'chart1');
-  const chart2 = new Chart(app, 'chart2');
-  const chart3 = new Chart(app, 'chart3');
+    // WHEN
+    const chart1 = new Chart(app, 'chart1');
+    const chart2 = new Chart(app, 'chart2');
+    const chart3 = new Chart(app, 'chart3');
 
-  const obj1 = new ApiObject(chart1, 'obj1', { apiVersion: 'v1', kind: 'Kind1' });
-  const obj2 = new ApiObject(chart2, 'obj2', { apiVersion: 'v1', kind: 'Kind2' });
-  const obj3 = new ApiObject(chart3, 'obj3', { apiVersion: 'v1', kind: 'Kind3' });
+    const obj1 = new ApiObject(chart1, 'obj1', {
+      apiVersion: 'v1',
+      kind: 'Kind1',
+    });
+    const obj2 = new ApiObject(chart2, 'obj2', {
+      apiVersion: 'v1',
+      kind: 'Kind2',
+    });
+    const obj3 = new ApiObject(chart3, 'obj3', {
+      apiVersion: 'v1',
+      kind: 'Kind3',
+    });
 
-  Node.of(obj1).addDependency(obj2);
-  Node.of(obj2).addDependency(obj3);
+    Node.of(obj1).addDependency(obj2);
+    Node.of(obj2).addDependency(obj3);
 
-  app.synth();
+    app.synth();
 
-  // THEN
-  expect(fs.readdirSync(app.outdir)).toEqual([
-    '0000-chart3.k8s.yaml',
-    '0001-chart2.k8s.yaml',
-    '0002-chart1.k8s.yaml',
-  ]);
-
+    // THEN
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
 });
 
 test('default output directory is "dist"', () => {
@@ -109,58 +173,91 @@ test('default output directory is "dist"', () => {
 
 test('app with dependent and independent charts', () => {
 
-  // GIVEN
-  const app = Testing.app();
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+      result: [
+        '0000-chart3.k8s.yaml',
+        '0001-chart1.k8s.yaml',
+        '0002-chart2.k8s.yaml',
+        '0003-chart4.k8s.yaml',
+      ],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP },
+      result: [],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [],
+    },
+  ];
 
-  // WHEN
-  const chart1 = new Chart(app, 'chart1');
-  new Chart(app, 'chart2');
-  const chart3 = new Chart(app, 'chart3');
-  new Chart(app, 'chart4');
+  for (const testSpec of testSpecs) {
+    // GIVEN
+    const app = Testing.app(testSpec.props);
 
-  Node.of(chart1).addDependency(chart3);
+    // WHEN
+    const chart1 = new Chart(app, 'chart1');
+    new Chart(app, 'chart2');
+    const chart3 = new Chart(app, 'chart3');
+    new Chart(app, 'chart4');
 
-  app.synth();
+    Node.of(chart1).addDependency(chart3);
 
-  // THEN
-  expect(fs.readdirSync(app.outdir)).toEqual([
-    '0000-chart3.k8s.yaml',
-    '0001-chart1.k8s.yaml',
-    '0002-chart2.k8s.yaml',
-    '0003-chart4.k8s.yaml',
-  ]);
+    app.synth();
 
+    // THEN
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
 });
 
 test('app with chart dependencies via custom constructs', () => {
-
   class CustomConstruct extends Construct {
-
     public obj: ApiObject;
 
     constructor(scope: Construct, id: string) {
       super(scope, id);
 
-      this.obj = new ApiObject(this, `${id}obj`, { apiVersion: 'v1', kind: 'CustomConstruct' });
+      this.obj = new ApiObject(this, `${id}obj`, {
+        apiVersion: 'v1',
+        kind: 'CustomConstruct',
+      });
     }
   }
 
-  const app = Testing.app();
-  const chart1 = new Chart(app, 'chart1');
-  const chart2 = new Chart(app, 'chart2');
+  const testSpecs = [
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_CHART },
+      result: ['0000-chart2.k8s.yaml', '0001-chart1.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_APP },
+      result: ['app.k8s.yaml'],
+    },
+    {
+      props: { yamlOutputType: YamlOutputType.FILE_PER_RESOURCE },
+      result: [
+        'v1.CustomConstruct.chart1-microservice-microserviceobj-c8e1164f.k8s.yaml',
+        'v1.CustomConstruct.chart2-database-databaseobj-c8b5eba3.k8s.yaml',
+      ],
+    },
+  ];
 
-  const microService = new CustomConstruct(chart1, 'MicroService');
-  const dataBase = new CustomConstruct(chart2, 'DataBase');
+  for (const testSpec of testSpecs) {
+    const app = Testing.app(testSpec.props);
+    const chart1 = new Chart(app, 'chart1');
+    const chart2 = new Chart(app, 'chart2');
 
-  Node.of(microService).addDependency(dataBase);
+    const microService = new CustomConstruct(chart1, 'MicroService');
+    const dataBase = new CustomConstruct(chart2, 'DataBase');
 
-  app.synth();
+    Node.of(microService).addDependency(dataBase);
 
-  expect(fs.readdirSync(app.outdir)).toEqual([
-    '0000-chart2.k8s.yaml',
-    '0001-chart1.k8s.yaml',
-  ]);
+    app.synth();
 
+    expect(fs.readdirSync(app.outdir)).toEqual(testSpec.result);
+  }
 });
 
 test('synth calls validate', () => {


### PR DESCRIPTION
This adds an optional configuration value to AppProps, to allow the output from the App to be divided into files in a couple different ways:

- One YAML file for the entire App
- One YAML file per chart, which is the current behavior, and the new default
- One YAML file per K8S resource, with the file name formatted as `${ApiVersion}.${Kind}.${Name}.k8s.yaml`

This should be backwards compatible, as the per chart behavior has not changed.

I still need to write tests for the non-default modes, but as it stands right now, the current tests pass locally. I'm open to suggestions on a better way of implementing this, it may not be as intuitive as I think it is.

Fixes #115 

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
