### PR TITLE
feat: add flag to control upgrade check

### DIFF
--- a/packages/cdk8s-cli/src/cli/index.ts
+++ b/packages/cdk8s-cli/src/cli/index.ts
@@ -3,16 +3,22 @@ import * as yargs from 'yargs';
 import { upgradeAvailable } from '../upgrades';
 
 async function main() {
-  const versions = upgradeAvailable();
-  if (versions) {
-    console.error('------------------------------------------------------------------------------------------------');
-    console.error(colors.yellow(`A new version ${versions.latest} of cdk8s-cli is available (current ${versions.current}).`));
-    console.error(colors.yellow('Run "npm install -g cdk8s-cli" to install the latest version on your system.'));
-    console.error(colors.yellow('For additional installation methods, see https://cdk8s.io/docs/latest/getting-started'));
-    console.error('------------------------------------------------------------------------------------------------');
-  }
-
   const ya = yargs
+    .option("check-upgrade", {type: "boolean", desc: "Check for cdk8s-cli upgrade", default: true})
+    .check(argv => {
+      if(argv.checkUpgrade) {
+        const versions = upgradeAvailable();
+        if (versions) {
+          console.error('------------------------------------------------------------------------------------------------');
+          console.error(colors.yellow(`A new version ${versions.latest} of cdk8s-cli is available (current ${versions.current}).`));
+          console.error(colors.yellow('Run "npm install -g cdk8s-cli" to install the latest version on your system.'));
+          console.error(colors.yellow('For additional installation methods, see https://cdk8s.io/docs/latest/getting-started'));
+          console.error('------------------------------------------------------------------------------------------------');
+        }
+      }
+
+      return true
+    }, true)
     .commandDir('cmds')
     .recommendCommands()
     .wrap(yargs.terminalWidth())


### PR DESCRIPTION
Hi,

This PR intends to define a new flag on the cdk8s-cli (i.e. `--check-upgrade`) to control available upgrade check trigger while running the command.

Regards

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
