### PR TITLE
fix(docs): correct language tab indentation

### DIFF
--- a/docs/cli/import.md
+++ b/docs/cli/import.md
@@ -61,13 +61,12 @@ imports. You could use them in this fashion:
     ```javascript
     import { Cluster } from './imports/example-cluster';
     import { Autoscaler } from './imports/example-autoscaler';
-
-```
+    ```
 
 === "Python"
     ```python
     not yet supported
-```
+    ```
 
 ## Import Types
 


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

I just found [a broken doc for import](https://cdk8s.io/docs/v1.0.0-beta.10/cli/import/#module-name) when I read the page. 

It is because of the wrong indentation for the code blocks.

I checked it rendered correctly in my local.

