### PR TITLE
docs: fix typo

### DIFF
--- a/docs/plus/index.md
+++ b/docs/plus/index.md
@@ -34,7 +34,7 @@ import * as path from 'path';
 // our cdk app
 const app = new cdk8s.App();
 
-// our kuberentes chart
+// our kubernetes chart
 const chart = new cdk8s.Chart(app, 'my-chart');
 
 // lets create a volume that contains our app.


### PR DESCRIPTION
This pull request resolves #581. It fixes a typo, 'kuberentes' → 'kubernetes'.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
