### PR TITLE
fix: multiline string with line greater than 80 chars are malformed

### DIFF
--- a/packages/cdk8s/API.md
+++ b/packages/cdk8s/API.md
@@ -1262,6 +1262,19 @@ static save(filePath: string, docs: Array<any>): void
 
 
 
+#### *static* stringify(doc)🔹 <a id="cdk8s-yaml-stringify"></a>
+
+Stringify a document into yaml.
+
+```ts
+static stringify(doc: any): string
+```
+
+* **doc** (<code>any</code>)  An object.
+
+__Returns__:
+* <code>string</code>
+
 #### *static* tmp(docs)🔹 <a id="cdk8s-yaml-tmp"></a>
 
 Saves a set of YAML documents into a temp file (in /tmp).

--- a/packages/cdk8s/src/yaml.ts
+++ b/packages/cdk8s/src/yaml.ts
@@ -25,9 +25,18 @@ export class Yaml {
     // NOTE: we convert undefined values to null, but ignore any documents that
     //  are undefined
     const data = docs.map(
-      r => r === undefined ? '\n' : YAML.stringify(r, { keepUndefined: true }),
+      r => r === undefined ? '\n' : Yaml.stringify(r),
     ).join('---\n');
     fs.writeFileSync(filePath, data, { encoding: 'utf-8' });
+  }
+
+  /**
+   * Stringify a document into yaml
+   * @param doc An object
+   */
+  public static stringify(doc: any) {
+    // Disable lineWidth to avoid loosing the \n into a multi-line parameter with long lines. 
+    return YAML.stringify(doc, { keepUndefined: true, lineWidth: 0 });
   }
 
   /**

--- a/packages/cdk8s/test/__snapshots__/yaml.test.ts.snap
+++ b/packages/cdk8s/test/__snapshots__/yaml.test.ts.snap
@@ -256,6 +256,15 @@ Array [
 ]
 `;
 
+exports[`multi-line text block with long line keep line break 1`] = `
+"foo: |-
+  [section]
+      abc: s
+      def: 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+bar: something
+"
+`;
+
 exports[`save empty documents are respected 1`] = `
 "{}
 ---

--- a/packages/cdk8s/test/yaml.test.ts
+++ b/packages/cdk8s/test/yaml.test.ts
@@ -97,3 +97,13 @@ test('yaml 1.1 octal numbers are parsed correctly', () => {
 
   expect(Yaml.load(filePath)).toEqual([{ foo: 493 }]);
 });
+
+test('multi-line text block with long line keep line break', () => {
+  const yamlString = {
+    foo: `[section]
+    abc: s
+    def: 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789`,
+    bar: 'something',
+  };
+  expect(Yaml.stringify(yamlString)).toMatchSnapshot();
+});


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

Fix #588 by changing the max line length to 0 (disabled). I've made the choice to add a public stringify to make sure it is testable (without writing to the file system). 