### PR TITLE
chore: update organization URL path to cdk8s-team

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ The general workflow for code contributions:
 All pull requests should be tracked with a GitHub issue.
 
 You should search for an [existing
-issue](https://github.com/awslabs/cdk8s/issues) or raise a [new
+issue](https://github.com/cdk8s-team/cdk8s/issues) or raise a [new
 bug or suggestion](#reporting-issues).
 
 
@@ -129,7 +129,7 @@ Out tests utilize [jest snapshot testing](https://jestjs.io/docs/en/snapshot-tes
 
 ### Integration Tests
 
-Integration tests are executed *against the latest published modules*. 
+Integration tests are executed *against the latest published modules*.
 This means that in order to execute integration tests against a development version, you'lol need to `yarn link`
 your local version to this repository (all deps are at the root):
 
@@ -189,11 +189,11 @@ Or, run this from the root of the repo:
 
 #### Docker environment for integration tests
 
-Due to the polyglot nature of the [jsii](https://github.com/aws/jsii) tools used by cdk8s, 
-the toolchain requirements are somewhat more complicated than for most projects.  To 
+Due to the polyglot nature of the [jsii](https://github.com/aws/jsii) tools used by cdk8s,
+the toolchain requirements are somewhat more complicated than for most projects.  To
 help with this, you can use the `jsii/superchain` docker image that includes all the required tools.
 
-In order to get an interactive shell within a superchain container you can use the 
+In order to get an interactive shell within a superchain container you can use the
 following command.
 
 ```console
@@ -209,7 +209,7 @@ $ yarn run package
 $ yarn integ:update
 ```
 
-> Note: this may leave some files owned as the docker root user id.  These will need to 
+> Note: this may leave some files owned as the docker root user id.  These will need to
   be cleaned up manually.
 
 ### Pull Requests
@@ -236,7 +236,7 @@ release. Therefore please following these guidelines to the letter:
 
 Documentation is rendered from markdown using
 [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) and sourced from
-the [`docs`](https://github.com/awslabs/cdk8s/tree/master/docs) directory.
+the [`docs`](https://github.com/cdk8s-team/cdk8s/tree/master/docs) directory.
 
 API documentation for `cdk8s` and all `cdk8s-plus-*` packages is auto-generated from inline
 docstrings during build.
@@ -260,11 +260,11 @@ This will serve a local web server with the website.
 ## Examples
 
 Examples are stored under
-[`examples`](https://github.com/awslabs/cdk8s/tree/master/examples) and
+[`examples`](https://github.com/cdk8s-team/cdk8s/tree/master/examples) and
 organized according to programming language.
 
 Every example also has an entry under
-[`docs/examples/xxx`](https://github.com/awslabs/cdk8s/tree/master/docs/examples)
+[`docs/examples/xxx`](https://github.com/cdk8s-team/cdk8s/tree/master/docs/examples)
 which describes the example and includes links to the source code (on the main
 branch).
 
@@ -282,7 +282,7 @@ To create an RFC follow this process:
    - Title should represent the title of the RFC.
    - Description should provide the motivation for the RFC.
 2. Create a markdown file based off of
-   [rfc/0000-template.md](https://github.com/awslabs/cdk8s/blob/master/rfc/0000-template.md) under the
+   [rfc/0000-template.md](https://github.com/cdk8s-team/cdk8s/blob/master/rfc/0000-template.md) under the
    `rfc/<nnnn>-<title-of-rfc>` where `<nnnn>` is the tracking issue number and
    `<title-of-rfc>` is a symbolic name for the title. For example:
    `rfc/0030-construct-operators.md`.
@@ -328,7 +328,7 @@ $ git push origin master
 ```
 
 This will trigger the [release
-workflow](https://github.com/awslabs/cdk8s/blob/master/.github/workflows/release.yml)
+workflow](https://github.com/cdk8s-team/cdk8s/blob/master/.github/workflows/release.yml)
 which will release to all package managers and will also create a GitHub release
 with a tag.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](./website/static/images/opengraph.jpg)
 
 ![Stability:Alpha](https://img.shields.io/badge/stability-alpha-orange)
-![Release](https://github.com/awslabs/cdk8s/workflows/Release/badge.svg)
+![Release](https://github.com/cdk8s-team/cdk8s/workflows/Release/badge.svg)
 [![npm version](https://badge.fury.io/js/cdk8s.svg)](https://badge.fury.io/js/cdk8s)
 [![PyPI version](https://badge.fury.io/py/cdk8s.svg)](https://badge.fury.io/py/cdk8s)
 [![NuGet version](https://badge.fury.io/nu/Org.Cdk8s.svg)](https://badge.fury.io/nu/Org.Cdk8s)
@@ -69,9 +69,9 @@ See the [Getting Started](https://cdk8s.io/docs/latest/getting-started) guide in
 Interacting with the community and the development team is a great way to
 contribute to the project. Please consider the following venues (in order):
 
-- Search [open issues](https://github.com/awslabs/cdk8s/issues)
+- Search [open issues](https://github.com/cdk8s-team/cdk8s/issues)
 - Stack Overflow: [cdk8s](https://stackoverflow.com/questions/tagged/cdk8s)
-- File a [new issue](https://github.com/awslabs/cdk8s/issues/new/choose)
+- File a [new issue](https://github.com/cdk8s-team/cdk8s/issues/new/choose)
 - Mailing list: [cdk8s](https://groups.google.com/forum/#!forum/cdk8s)
 - Slack: #cdk8s channel in [cdk.dev](https://cdk.dev)
 
@@ -85,7 +85,7 @@ See our [Examples Directory](./examples).
 
 ## Roadmap
 
-See our [roadmap](https://github.com/awslabs/cdk8s/projects/1) for details about our plans for the project.
+See our [roadmap](https://github.com/cdk8s-team/cdk8s/projects/1) for details about our plans for the project.
 
 ## Community
 

--- a/docs/concepts/escape-hatches.md
+++ b/docs/concepts/escape-hatches.md
@@ -11,7 +11,7 @@ You may need to use an escape hatch in the following cases:
 1. You are using an imported API object (e.g. `KubeDeployment`) and there is an
    issue with the schema or a bug in "import" which results in an invalid
    manifest or missing fields (as an example see
-   [issue #140](https://github.com/awslabs/cdk8s/issues/140)).
+   [issue #140](https://github.com/cdk8s-team/cdk8s/issues/140)).
 2. You are using a high-level API (e.g. CDK8s+) which does not expose some
    functionality which exists in the lower-level resources.
 

--- a/docs/examples/crd.md
+++ b/docs/examples/crd.md
@@ -2,9 +2,9 @@
 
 Shows how to import and use [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 
-- [TypeScript](https://github.com/awslabs/cdk8s/tree/master/examples/typescript/crd)
-- [Python](https://github.com/awslabs/cdk8s/tree/master/examples/python/crd)
-- [Java](https://github.com/awslabs/cdk8s/tree/master/examples/java/crd)
+- [TypeScript](https://github.com/cdk8s-team/cdk8s/tree/master/examples/typescript/crd)
+- [Python](https://github.com/cdk8s-team/cdk8s/tree/master/examples/python/crd)
+- [Java](https://github.com/cdk8s-team/cdk8s/tree/master/examples/java/crd)
 
 !!! note
     We try to maintain the same set of examples in all supported languages.

--- a/docs/examples/hello.md
+++ b/docs/examples/hello.md
@@ -2,9 +2,9 @@
 
 Deploys [hello-kubernetes](https://github.com/paulbouwer/hello-kubernetes) as a Service behind a LoadBalancer.
 
-- [TypeScript](https://github.com/awslabs/cdk8s/tree/master/examples/typescript/hello)
-- [Python](https://github.com/awslabs/cdk8s/tree/master/examples/python/hello)
-- [Java](https://github.com/awslabs/cdk8s/tree/master/examples/java/hello)
+- [TypeScript](https://github.com/cdk8s-team/cdk8s/tree/master/examples/typescript/hello)
+- [Python](https://github.com/cdk8s-team/cdk8s/tree/master/examples/python/hello)
+- [Java](https://github.com/cdk8s-team/cdk8s/tree/master/examples/java/hello)
 
 !!! note
     We try to maintain the same set of examples in all supported languages.

--- a/docs/examples/plus-elasticsearch.md
+++ b/docs/examples/plus-elasticsearch.md
@@ -2,7 +2,7 @@
 
 Creating a query service on top of Elasticsearch with CDK8s+
 
-- [TypeScript](https://github.com/awslabs/cdk8s/tree/master/examples/typescript/cdk8s-plus-elasticsearch-query)
+- [TypeScript](https://github.com/cdk8s-team/cdk8s/tree/master/examples/typescript/cdk8s-plus-elasticsearch-query)
 
 !!! note
     We try to maintain the same set of examples in all supported languages.

--- a/docs/examples/plus-ingress.md
+++ b/docs/examples/plus-ingress.md
@@ -2,7 +2,7 @@
 
 Example of using CDK8s+ `Ingress` resource.
 
-- [TypeScript](https://github.com/awslabs/cdk8s/tree/master/examples/typescript/cdk8s-plus-ingress)
+- [TypeScript](https://github.com/cdk8s-team/cdk8s/tree/master/examples/typescript/cdk8s-plus-ingress)
 
 !!! note
     We try to maintain the same set of examples in all supported languages.

--- a/docs/examples/podinfo.md
+++ b/docs/examples/podinfo.md
@@ -2,7 +2,7 @@
 
 Exploration of high-level APIs for **Deployment**, **Service**, **AutoScaler** and **Ingress** based on the [podinfo project](https://hub.docker.com/r/stefanprodan/podinfo).
 
-- [TypeScript](https://github.com/awslabs/cdk8s/tree/master/examples/typescript/podinfo)
+- [TypeScript](https://github.com/cdk8s-team/cdk8s/tree/master/examples/typescript/podinfo)
 
 !!! note
     We try to maintain the same set of examples in all supported languages.

--- a/docs/examples/web-service.md
+++ b/docs/examples/web-service.md
@@ -2,9 +2,9 @@
 
 Demonstrates how to make your first high-level construct which represents a web service which abstracts the `hello` example from earlier into a reusable piece of infrastructure.
 
-- [TypeScript](https://github.com/awslabs/cdk8s/tree/master/examples/typescript/web-service)
-- [Python](https://github.com/awslabs/cdk8s/tree/master/examples/python/web-service)
-- [Java](https://github.com/awslabs/cdk8s/tree/master/examples/java/web-service)
+- [TypeScript](https://github.com/cdk8s-team/cdk8s/tree/master/examples/typescript/web-service)
+- [Python](https://github.com/cdk8s-team/cdk8s/tree/master/examples/python/web-service)
+- [Java](https://github.com/cdk8s-team/cdk8s/tree/master/examples/java/web-service)
 
 !!! note
     We try to maintain the same set of examples in all supported languages.

--- a/docs/support.md
+++ b/docs/support.md
@@ -3,8 +3,8 @@
 Interacting with the community and the development team is a great way to
 contribute to the project. Please consider the following venues (in order):
 
-* Search [open issues](https://github.com/awslabs/cdk8s/issues)
+* Search [open issues](https://github.com/cdk8s-team/cdk8s/issues/)
 * Stack Overflow: [cdk8s](https://stackoverflow.com/questions/tagged/cdk8s)
-* File a [new issue](https://github.com/awslabs/cdk8s/issues/new/choose)
+* File a [new issue](https://github.com/cdk8s-team/cdk8s/issues/new/choose)
 * Mailing list: [cdk8s](https://groups.google.com/forum/#!forum/cdk8s)
 * Slack: #cdk8s channel in [cdk.dev](https://cdk.dev)

--- a/examples/typescript/cdk8s-plus-elasticsearch-query/README.md
+++ b/examples/typescript/cdk8s-plus-elasticsearch-query/README.md
@@ -6,15 +6,15 @@ This directory contains an a small query service that hits an elasticsearch endp
 
 The Elasticsearch cluster is created using the [ElasticCloud CRD](https://download.elastic.co/downloads/eck/1.1.2/all-in-one.yaml). The code has been pre-imported and [included](./imports/elasticsearch.k8s.elastic.co/elasticsearch.ts) in this application.
 
-> To learn mode about using CRD's with `cdk8s`, see [Custom Resource Definitions](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-cli#custom-resource-definitions-crds) and [CRD Example](https://github.com/awslabs/cdk8s/tree/master/examples/typescript/crd)
+> To learn mode about using CRD's with `cdk8s`, see [Custom Resource Definitions](https://github.com/cdk8s-team/cdk8s/tree/master/packages/cdk8s-cli#custom-resource-definitions-crds) and [CRD Example](https://github.com/cdk8s-team/cdk8s/tree/master/examples/typescript/crd)
 
 #### Query Deployment
 
-A kubernetes deployment is created using the `cdk8s-plus` [`Deployment`](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-plus#deployment) construct.
+A kubernetes deployment is created using the `cdk8s-plus` [`Deployment`](https://github.com/cdk8s-team/cdk8s/tree/master/packages/cdk8s-plus#deployment) construct.
 
 #### Query Service
 
-A kubecrnetes service that serves the deployment is created using the `cdk8s-plus` [`Service`](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-plus#service) construct.
+A kubecrnetes service that serves the deployment is created using the `cdk8s-plus` [`Service`](https://github.com/cdk8s-team/cdk8s/tree/master/packages/cdk8s-plus#service) construct.
 
 ## Build
 
@@ -49,4 +49,3 @@ To apply the manifest to your Kubernetes cluster, run:
 This example has a [`data.txt`](./data.txt) file that contains some mock documents that can be indexed to the Elasticsearch cluster, for quick development iterations.
 
 `npm run index-mock-data`
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: CDK8s Documentation
-repo_url: https://github.com/awslabs/cdk8s
-repo_name: awslabs/cdk8s
+repo_url: https://github.com/cdk8s-team/cdk8s
+repo_name: cdk8s-team/cdk8s
 edit_uri: blob/master/docs
 theme:
   name: material
@@ -39,6 +39,6 @@ extra:
     - icon: fontawesome/brands/slack
       link: https://cdk.dev
     - icon: fontawesome/brands/github
-      link: https://github.com/awslabs/cdk8s
+      link: https://github.com/cdk8s-team/cdk8s
 
 copyright: © 2020, Amazon Web Services, Inc. or its affiliates. © cdk8s project authors. All rights reserved.

--- a/research/README.md
+++ b/research/README.md
@@ -7,8 +7,8 @@ The goal of this facility is two fold:
 1. Share the research being done by core team members with the community.
 2. Collect additional ideas thought of by the community.
 
-Any form of contribution is done by simply creating a pull request with your suggested content. 
-We also welcome you to [open](https://github.com/awslabs/cdk8s/issues/new?assignees=&labels=enhancement&template=feature-request---suggestion.md&title=%5BSuggestion%5D+new+suggestion) 
+Any form of contribution is done by simply creating a pull request with your suggested content.
+We also welcome you to [open](https://github.com/cdk8s-team/cdk8s/issues/new?assignees=&labels=enhancement&template=feature-request---suggestion.md&title=%5BSuggestion%5D+new+suggestion)
 an issue beforehand if you'd like to have a discussion prior to creating the pull request (highly encoureged).
 
 We are currently actively researching the following topics:

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -13,8 +13,8 @@
 {{- $link_concepts := (print $docs_root "/concepts") }}
 {{- $link_examples := (print $docs_root "/examples") }}
 {{- $link_contrib := (print $docs_root "/project/CONTRIBUTING") }}
-{{- $link_roadmap := "https://github.com/awslabs/cdk8s/projects/1" }}
-{{- $link_github := "https://github.com/awslabs/cdk8s" }}
+{{- $link_roadmap := "https://github.com/cdk8s-team/cdk8s/projects/1" }}
+{{- $link_github := "https://github.com/cdk8s-team/cdk8s" }}
 {{- $link_slack := "https://cdk.dev" }}
 {{- $link_license := "https://github.com/aws/aws-cdk/blob/master/LICENSE" }}
 {{- $link_coc := "https://github.com/cncf/foundation/blob/master/code-of-conduct.md" }}


### PR DESCRIPTION
Update organization URL path from `awslabs` to `cdk8s-team` to avoid broken links.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*