### PR TITLE
fix: library names in go reference header is wrong

### DIFF
--- a/docs/reference/cdk8s-plus-20/go.md
+++ b/docs/reference/cdk8s-plus-20/go.md
@@ -1,3 +1,3 @@
-# cdk8s-plus-17 (Go) <a name="API Reference"></a>
+# cdk8s-plus-20 (Go) <a name="API Reference"></a>
 
 For Go API reference, please visit <https://pkg.go.dev/github.com/cdk8s-team/cdk8s-plus-go/cdk8splus20>.

--- a/docs/reference/cdk8s-plus-21/go.md
+++ b/docs/reference/cdk8s-plus-21/go.md
@@ -1,3 +1,3 @@
-# cdk8s-plus-17 (Go) <a name="API Reference"></a>
+# cdk8s-plus-21 (Go) <a name="API Reference"></a>
 
 For Go API reference, please visit <https://pkg.go.dev/github.com/cdk8s-team/cdk8s-plus-go/cdk8splus21>.

--- a/docs/reference/cdk8s-plus-22/go.md
+++ b/docs/reference/cdk8s-plus-22/go.md
@@ -1,3 +1,3 @@
-# cdk8s-plus-17 (Go) <a name="API Reference"></a>
+# cdk8s-plus-22 (Go) <a name="API Reference"></a>
 
 For Go API reference, please visit <https://pkg.go.dev/github.com/cdk8s-team/cdk8s-plus-go/cdk8splus22>.


### PR DESCRIPTION
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*