### PR TITLE
fix(website): TS getting started is not clear enough with relation to synth

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,14 +55,6 @@ Now, we'll use the `cdk8s init` command to create a new CDK8s app:
     ...
     ```
 
-    Since TypeScript is a compiled language, we will need to compile `.ts` files to
-    `.js` in order to execute our CDK app. You can do that continuously in the
-    background like this:
-
-    ```console
-    $ npm run watch
-    ```
-
 === "Python"
     ```console
     $ mkdir hello
@@ -97,7 +89,17 @@ This will perform the following:
 
 ## Apps & Charts
 
-At this point, if you will see something like this:
+Apps are structured as a tree of **constructs**, which are composable units of
+abstraction. We will learn more about constructs soon.
+
+This initial code created by `cdk8s init` defines an app with a single, empty,
+chart.
+
+When you synthesize the app, a Kubernetes manifest YAML will be produced for
+each `Chart` in your app and will write it to the `dist` directory. At this point, the YAML
+file should be empty since we haven't defined any resources yet.
+
+Let have a look at the code:
 
 === "TypeScript"
     `main.ts`
@@ -120,6 +122,19 @@ At this point, if you will see something like this:
     app.synth();
     ```
 
+    To produce and inspect the generated manifest, you can run:
+
+    ```console
+    $ npm run compile && cdk8s synth
+    dist/hello.k8s.yaml
+
+    $ cat dist/hello.k8s.yaml
+    <EMPTY>
+    ```
+
+    > Note that since TypeScript is a compiled language, we will need to compile `.ts` files to `.js` in order to execute our CDK8s app. To avoid explicitly compiling every time, you can run a watch process in the background by running: `npm run watch`
+
+
 === "Python"
     `main.py`
 
@@ -140,6 +155,16 @@ At this point, if you will see something like this:
     MyChart(app, "hello")
 
     app.synth()
+    ```
+
+    To produce and inspect the generated manifest, you can run:
+
+    ```console
+    $ cdk8s synth
+    dist/hello.k8s.yaml
+
+    $ cat dist/hello.k8s.yaml
+    <EMPTY>
     ```
 
 === "Java"
@@ -173,6 +198,16 @@ At this point, if you will see something like this:
             app.synth();
         }
     }
+    ```
+
+    To produce and inspect the generated manifest, you can run:
+
+    ```console
+    $ cdk8s synth
+    dist/hello.k8s.yaml
+
+    $ cat dist/hello.k8s.yaml
+    <EMPTY>
     ```
 
 === "Go"
@@ -210,25 +245,15 @@ At this point, if you will see something like this:
     }
     ```
 
+    To produce and inspect the generated manifest, you can run:
 
-Apps are structured as a tree of **constructs**, which are composable units of
-abstraction. We will learn more about constructs soon.
+    ```console
+    $ cdk8s synth
+    dist/hello.k8s.yaml
 
-This initial code created by `cdk8s init` defines an app with a single, empty,
-chart.
-
-When you run `cdk8s synth`, a Kubernetes manifest YAML will be synthesized for
-each `Chart` in your app and will write it to the `dist` directory.
-
-You can try:
-
-```console
-$ cdk8s synth
-dist/hello.k8s.yaml
-
-$ cat dist/hello.k8s.yaml
-<EMPTY>
-```
+    $ cat dist/hello.k8s.yaml
+    <EMPTY>
+    ```
 
 ## Importing Constructs for the Kubernetes API
 
@@ -304,6 +329,12 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
     app.synth();
     ```
 
+    Now, to synthesize the app, run:
+
+    ```shell
+    npm run compile && cdk8s synth
+    ```
+
 === "Python"
     ```python
     #!/usr/bin/env python
@@ -342,6 +373,12 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
     MyChart(app, "hello")
 
     app.synth()
+    ```
+
+    Now, to synthesize the app, run:
+
+    ```shell
+    cdk8s synth
     ```
 
 === "Java"
@@ -449,8 +486,14 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
     }
     ```
 
+    Now, to synthesize the app, run:
+
+    ```shell
+    cdk8s synth
+    ```
+
 === "Go"
-    
+
     ```go
     package main
 
@@ -516,15 +559,11 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
     }
     ```
 
-Now, compile & synth this project:
+    Now, to synthesize the app, run:
 
-```shell
-cdk8s synth
-```
-
-!!! notice
-    In compiled languages, like Java and TypeScript, you'll need to compile your program
-    before running `cdk8s synth`.
+    ```shell
+    cdk8s synth
+    ```
 
 This will be contents of `hello.k8s.yaml`:
 


### PR DESCRIPTION
Currently, the instructions for TS mention force the user to run a watch command in order to properly synth the app.

<img width="714" alt="Screen Shot 2021-10-06 at 9 12 36 PM" src="https://user-images.githubusercontent.com/1428812/136259906-ae278b29-03ce-469e-8edb-f2bc328bcf93.png">

This instruction is easily overlooked since its not intuitive, in addition, it creates a complexity of having to run a background process. 

Skipping this command will make it so running `cdk8s synth` further down the guide will have no affect. 

Instead, we instruct the user to run a `npm run compile && cdk8s synth` command in order to ensure compilation happens. As for running watch, we now mention this in a quote as an option to forgo explicit compilation - but this is not the main path.

Here is how TS will look like following this PR:

<img width="442" alt="Screen Shot 2021-10-06 at 9 06 49 PM" src="https://user-images.githubusercontent.com/1428812/136260219-e70b926c-fa75-47f8-b87e-7ea5802c84f6.png">
<img width="429" alt="Screen Shot 2021-10-06 at 9 07 18 PM" src="https://user-images.githubusercontent.com/1428812/136260235-badfac92-a195-4f3e-a185-de53234124ea.png">

In contrast with python for example, where we simply use `cdk8s synth`.

<img width="431" alt="Screen Shot 2021-10-06 at 9 09 02 PM" src="https://user-images.githubusercontent.com/1428812/136260312-7f1db9b0-935d-4a3a-a285-f299ce40dbc4.png">
<img width="434" alt="Screen Shot 2021-10-06 at 9 09 20 PM" src="https://user-images.githubusercontent.com/1428812/136260320-288afaf6-a220-4fd3-a3f3-568f6750b044.png">
