### PR TITLE
fix(docs): undefined id error on index doc Go section

### DIFF
--- a/docs/plus/index.md
+++ b/docs/plus/index.md
@@ -270,6 +270,7 @@ app.synth();
 
     ```go
     app := cdk8s.NewApp(nil)
+    id := "ubuntu"
     chart := cdk8s.NewChart(app, jsii.String(id), nil)
 
     cdk8splus22.NewDeployment(chart, jsii.String("Deployment"), &cdk8splus22.DeploymentProps{

--- a/docs/plus/index.md
+++ b/docs/plus/index.md
@@ -270,8 +270,7 @@ app.synth();
 
     ```go
     app := cdk8s.NewApp(nil)
-    id := "ubuntu"
-    chart := cdk8s.NewChart(app, jsii.String(id), nil)
+    chart := cdk8s.NewChart(app, jsii.String("ubuntu"), nil)
 
     cdk8splus22.NewDeployment(chart, jsii.String("Deployment"), &cdk8splus22.DeploymentProps{
       Replicas: jsii.Number(3),


### PR DESCRIPTION
As originally written, the Go example in the index page throws an error because id is undefined. This PR fixes the document by defining id and setting it equal to "ubuntu" (since we are creating an ubuntu deployment)