### PR TITLE
chore: add link to Construct Hub in navigation menu

### DIFF
--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -110,10 +110,10 @@
                             <div>Resources</div>
                         </div>
                         <nav class="dropdown-list w-dropdown-list">
-                            <a href="{{ $link_constructs }}" target="_blank" class="dropdown-link w-dropdown-link">Find constructs</a>
                             <a href="{{ $link_examples }}" target="_blank" class="dropdown-link w-dropdown-link">Examples</a>
                             <a href="{{ $link_roadmap }}" target="_blank" class="dropdown-link w-dropdown-link">Roadmap</a>
                             <a href="{{ $link_contrib }}" target="_blank" class="dropdown-link w-dropdown-link">Contributors</a>
+                            <a href="{{ $link_constructs }}" target="_blank" class="dropdown-link w-dropdown-link">More CDK8s libraries</a>
                         </nav>
                     </div>
                     <div data-hover="" data-delay="0" class="w-dropdown">

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -16,6 +16,7 @@
 {{- $link_concepts := (print $docs_root "/concepts") }}
 {{- $link_examples := (print $docs_root "/examples") }}
 {{- $link_contrib := (print $docs_root "/project/CONTRIBUTING") }}
+{{- $link_constructs := "https://constructs.dev/search?q=&cdk=cdk8s&offset=0" }}
 {{- $link_roadmap := "https://github.com/cdk8s-team/cdk8s/projects/1" }}
 {{- $link_github := "https://github.com/cdk8s-team/cdk8s" }}
 {{- $link_slack := "https://cdk.dev" }}
@@ -109,6 +110,7 @@
                             <div>Resources</div>
                         </div>
                         <nav class="dropdown-list w-dropdown-list">
+                            <a href="{{ $link_constructs }}" target="_blank" class="dropdown-link w-dropdown-link">Find constructs</a>
                             <a href="{{ $link_examples }}" target="_blank" class="dropdown-link w-dropdown-link">Examples</a>
                             <a href="{{ $link_roadmap }}" target="_blank" class="dropdown-link w-dropdown-link">Roadmap</a>
                             <a href="{{ $link_contrib }}" target="_blank" class="dropdown-link w-dropdown-link">Contributors</a>

--- a/website/static/css/cdk8s.webflow.css
+++ b/website/static/css/cdk8s.webflow.css
@@ -444,7 +444,7 @@
   top: 0%;
   right: 0%;
   bottom: auto;
-  padding-top: 23px;
+  padding-top: 15px;
   padding-bottom: 0px;
   background-color: transparent;
 }
@@ -477,7 +477,7 @@
   width: 43px;
   height: 40px;
   padding-right: 0px;
-  padding-left: 0px;
+  padding-left: 10px;
 }
 
 .cncf-logo {


### PR DESCRIPTION

<img width="376" alt="Screen Shot 2021-11-22 at 10 44 28 AM" src="https://user-images.githubusercontent.com/5008987/142917625-3ff8c679-a6a7-4d62-973a-0c23d08f32dc.png">


Signed-off-by: Christopher Rybicki <rybickic@amazon.com>