### PR TITLE
fix: typo in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -302,7 +302,7 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
         // its a little confusing at first glance, but this is an inherent aspect of the constructs
         // programming model, and you will encounter it many times.
         // you can still perform an assignment of course, if you need to access
-        // atrtibutes of the resource in other parts of the code.
+        // attributes of the resource in other parts of the code.
 
         new KubeService(this, 'service', {
           spec: {
@@ -367,7 +367,7 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
             # its a little confusing at first glance, but this is an inherent aspect of the constructs
             # programming model, and you will encounter it many times.
             # you can still perform an assignment of course, if you need to access
-            # atrtibutes of the resource in other parts of the code.
+            # attributes of the resource in other parts of the code.
 
             k8s.KubeService(self, 'service',
                         spec=k8s.ServiceSpec(
@@ -466,7 +466,7 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
             // its a little confusing at first glance, but this is an inherent aspect of the constructs
             // programming model, and you will encounter it many times.
             // you can still perform an assignment of course, if you need to access
-            // atrtibutes of the resource in other parts of the code.
+            // attributes of the resource in other parts of the code.
 
             new KubeService(this, "service", serviceProps);
 
@@ -561,7 +561,7 @@ resources inspired by [paulbouwer](https://github.com/paulbouwer)'s
       // its a little confusing at first glance, but this is an inherent aspect of the constructs
       // programming model, and you will encounter it many times.
       // you can still perform an assignment of course, if you need to access
-      // atrtibutes of the resource in other parts of the code.
+      // attributes of the resource in other parts of the code.
 
       k8s.NewKubeDeployment(chart, jsii.String("deployment"), &k8s.KubeDeploymentProps{
         Spec: &k8s.DeploymentSpec{


### PR DESCRIPTION
... and replaced 'atrtibutes' by 'attributes'