### PR TITLE
feat: New yaml output type: Folder_per_chart_file_per_resource 

### DIFF
--- a/docs/reference/cdk8s/java.md
+++ b/docs/reference/cdk8s/java.md
@@ -2156,3 +2156,8 @@ Each resource is output to its own file.
 
 ---
 
+#### `FOLDER_PER_CHART_FILE_PER_RESOURCE` <a name="cdk8s.YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE"></a>
+
+Each chart is created as a folder. Each resource is output as a file in the appropriate folder.
+
+---

--- a/docs/reference/cdk8s/python.md
+++ b/docs/reference/cdk8s/python.md
@@ -2367,3 +2367,8 @@ Each resource is output to its own file.
 
 ---
 
+#### `FOLDER_PER_CHART_FILE_PER_RESOURCE` <a name="cdk8s.YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE"></a>
+
+Each chart is created as a folder. Each resource is output as a file in the appropriate folder.
+
+---

--- a/docs/reference/cdk8s/typescript.md
+++ b/docs/reference/cdk8s/typescript.md
@@ -1941,3 +1941,8 @@ Each resource is output to its own file.
 
 ---
 
+#### `FOLDER_PER_CHART_FILE_PER_RESOURCE` <a name="cdk8s.YamlOutputType.FOLDER_PER_CHART_FILE_PER_RESOURCE"></a>
+
+Each chart is created as a folder. Each resource is output as a file in the appropriate folder.
+
+---


### PR DESCRIPTION
This PR refers to documenting the changes from[ PR 143 ](https://github.com/cdk8s-team/cdk8s-core/pull/143 )in the cdk8s-core repo , which adds a new yaml output type:` folder_per_chart_file_per_resource`.

The new type allows users to elect to export their yaml resources as follows:

- Each chart creates a folder
- Each resource is created as a file and placed in the correct chart folder
This provides better organization and flexibility as the number of resources created increases