### PR TITLE
chore(java examples): remove dependency on com.google.guava:guava

### DIFF
--- a/examples/java/crd/pom.xml
+++ b/examples/java/crd/pom.xml
@@ -18,11 +18,6 @@
       <artifactId>constructs</artifactId>
       <version>3.2.34</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
-    </dependency>
   </dependencies>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/java/hello/pom.xml
+++ b/examples/java/hello/pom.xml
@@ -18,11 +18,6 @@
       <artifactId>constructs</artifactId>
       <version>3.2.34</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>30.0-jre</version>
-    </dependency>
   </dependencies>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/java/helm-bitnami/pom.xml
+++ b/examples/java/helm-bitnami/pom.xml
@@ -18,11 +18,6 @@
       <artifactId>constructs</artifactId>
       <version>3.3.71</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
-    </dependency>
   </dependencies>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/java/web-service/pom.xml
+++ b/examples/java/web-service/pom.xml
@@ -18,11 +18,6 @@
       <artifactId>constructs</artifactId>
       <version>3.2.34</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>30.0-jre</version>
-    </dependency>
   </dependencies>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
This dependency is not being used, and causing this repo to have a low severity security alert from [CVE-2020-8908](https://github.com/cdk8s-team/cdk8s/security/dependabot/examples/java/crd/pom.xml/com.google.guava:guava/open). So, let's remove it. 

To verify removing this dependency is okay, I built and synth'ed all of the java examples locally. 