### PR TITLE
chore: refactor integ tests to use new projen apis

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "14"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}
@@ -14,5 +17,5 @@ pull_request_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=integ (windows-latest)
-      - status-success=integ (ubuntu-latest)
       - status-success=integ (macos-latest)
+      - status-success=integ (ubuntu-latest)


### PR DESCRIPTION
Supersedes #804

This updates `.projenrc.js` to avoid having to manually override all of `mergify.yml`.

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>