### PR TITLE
chore: clarify why cdk8s+ is vended in multiple packages

### DIFF
--- a/docs/plus/index.md
+++ b/docs/plus/index.md
@@ -41,6 +41,13 @@ their manifests to the Kubernetes version they are operating. This way, users
 are only exposed to a set of capabilities offered by their specific cluster,
 preventing deployment errors caused by version mismatches.
 
+For example, imagine we had published a single library for all Kubernetes versions (call it `cdk8s-plus`). 
+This library would have had support for the [`namespaceSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#namespace-selector) property when configuring pod affinity rules. This property was only added in Kubernetes 1.21.0.
+
+Now imagine you operate Kubernetes 1.20.0. In such a case, you would have access to the `namespaceSelector` property, even though
+it is unsupported, and will result in a deployment failure if you use it. With a dedicated package, this property would not be available
+for you to (mis)use.
+
 ### I operate Kubernetes version `1.XX` - which cdk8s+ library should I be using?
 
 If there is a `cdk8s-plus-XX` library that matches your target Kubernetes


### PR DESCRIPTION
Added a specific example that would cause a poor user experience if we vended a single library.