### PR TITLE
fix: docs refer to non existent `EnvValue.fromSecret` function

### DIFF
--- a/docs/plus/container.md
+++ b/docs/plus/container.md
@@ -26,7 +26,7 @@ container.addEnv('endpoint', kplus.EnvValue.fromConfigMap(backendsConfig, 'endpo
 
 // use a specific key from a secret.
 const credentials = kplus.Secret.fromSecretName('credentials');
-container.addEnv('password', kplus.EnvValue.fromSecret(credentials, 'password'));
+container.addEnv('password', kplus.EnvValue.fromSecretValue({ secret: credentials, key: 'password' }));
 ```
 
 ## Volume Mounts


### PR DESCRIPTION
The API does not have the function `kplus.EnvValue.fromSecret` which was used in example. Changed it to use `kplus.EnvValue.fromSecretValue` instead.