### PR TITLE
fix(docs): overflow y-axis bugs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,11 +8,9 @@ theme:
   logo: assets/logo.png
   palette:
     scheme: default
-    primary: "#133650"
+    primary: '#133650'
   features:
     - navigation.instant
-    # - navigation.tabs
-    - header.autohide
 
 extra_css:
   - assets/extra.css
@@ -20,7 +18,8 @@ extra_css:
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.details
   - admonition
   - pymdownx.emoji:


### PR DESCRIPTION
## Summary

This PR fixes a bug with tab context boxes which was causing tab context boxes to not render correctly. This also caused multiple page breaking overflow issues.

To fix this I added the required param `alternate_style: true` to `- pymdownx.tabbed:` as mentioned in the [tabbed docs](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#tabbed)

I also disabled the header's autohide feature. This is unrelated to the bug. I disabled it because it seemed like it was causing an awkward space between the nav trees and top of page. 

Demo of nav menu overflowing footer
![CleanShot 2022-08-16 at 10 34 44](https://user-images.githubusercontent.com/17558268/185007857-47fee24e-b288-4a06-bb84-51742b983b16.gif)

Demo of autohiding header
![CleanShot 2022-08-16 at 09 32 23](https://user-images.githubusercontent.com/17558268/185007846-41555992-d966-496d-9c85-a27e7faa6947.gif)



