### PR TITLE
chore(docs): document aliased imports

### DIFF
--- a/examples/go/crd/cdk8s.yaml
+++ b/examples/go/crd/cdk8s.yaml
@@ -2,7 +2,7 @@ language: go
 app: go run .
 imports:
   - k8s@1.17.0
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
+  - io_jenkins_crd:=https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
   - mattermost_crd.yaml
   - version.yaml
-  - https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml
+  - serving_crds:=https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml

--- a/examples/java/crd/cdk8s.yaml
+++ b/examples/java/crd/cdk8s.yaml
@@ -2,7 +2,7 @@ language: java
 app: mvn exec:java -Dexec.mainClass="com.mycompany.app.Main"
 imports:
   - k8s@1.17.0
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
+  - io_jenkins_crd:=https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
   - mattermost_crd.yaml
   - version.yaml
-  - https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml
+  - serving_crds:=https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml

--- a/examples/python/crd/cdk8s.yaml
+++ b/examples/python/crd/cdk8s.yaml
@@ -2,7 +2,7 @@ language: python
 app: pipenv run ./main.py
 imports:
   - k8s@1.17.0
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
+  - io_jenkins_crd:=https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
   - mattermost_crd.yaml
   - version.yaml
-  - https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml
+  - serving_crds:=https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml

--- a/examples/typescript/crd/cdk8s.yaml
+++ b/examples/typescript/crd/cdk8s.yaml
@@ -2,7 +2,7 @@ app: node index.js
 language: typescript
 imports:
   - k8s@1.17.0
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
+  - io_jenkins_crd:=https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/deploy/crds/jenkins.io_jenkins_crd.yaml
   - mattermost:=mattermost_crd.yaml
   - version.yaml
-  - https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml
+  - serving_crds:=https://github.com/knative/serving/releases/download/v0.14.0/serving-crds.yaml

--- a/test/test-imports/go/cdk8s.yaml
+++ b/test/test-imports/go/cdk8s.yaml
@@ -5,5 +5,5 @@ imports:
   - mattermost:=mattermost_crd.yaml
 
   # pin to a specific commit, otherwise we have a non-deterministic test
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
+  - io_jenkins_crd:=https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
   - example_multiple_crd.yaml

--- a/test/test-imports/python/cdk8s.yaml
+++ b/test/test-imports/python/cdk8s.yaml
@@ -5,5 +5,5 @@ imports:
   - mattermost:=mattermost_crd.yaml
 
   # pin to a specific commit, otherwise we have a non-deterministic test
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
+  - io_jenkins_crd:=https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
   - example_multiple_crd.yaml

--- a/test/test-imports/typescript/cdk8s.yaml
+++ b/test/test-imports/typescript/cdk8s.yaml
@@ -4,6 +4,6 @@ imports:
   - k8s@1.17.0
 
   # pin to a specific commit, otherwise we have a non-deterministic test
-  - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
+  - io_jenkins_crd:=https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
   - mattermost:=mattermost_crd.yaml
   - example_multiple_crd.yaml


### PR DESCRIPTION
### DESCRIPTION
Resolves the issue https://github.com/cdk8s-team/cdk8s/issues/883
 
### CHANGES
Instead of importing like this:
```
imports:
 - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
````
Using alias for the imports:

```
imports:
  - io_jenkins_crd:=https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/6edd2e554f40d7ee03f1cf6e12feb278cb5097f0/deploy/crds/jenkins.io_jenkins_crd.yaml
```