### PR TITLE
fix(website): incorrect golang code snippets in getting started guide 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1132,7 +1132,6 @@ Here's how to implement `WebService`:
     )
 
     type WebServiceProps struct {
-      constructs.ConstructOptions
       Image         *string
       Replicas      *float64
       Port          *float64
@@ -1140,11 +1139,7 @@ Here's how to implement `WebService`:
     }
 
     func NewWebService(scope constructs.Construct, id *string, props *WebServiceProps) constructs.Construct {
-      var cprops constructs.ConstructOptions
-      if props != nil {
-        cprops = props.ConstructOptions
-      }
-      construct := constructs.NewConstruct(scope, id, &cprops)
+      construct := constructs.NewConstruct(scope, id)
 
       replicas := props.Replicas
       if replicas == nil {


### PR DESCRIPTION
`ConstructOptions` was removed in constructs v10 and we didn't update the docs. 

The code now matches the [example](https://github.com/cdk8s-team/cdk8s-examples/blob/main/go/cdk8s-composition/webservice.go) and properly compiles.

Fixes https://github.com/cdk8s-team/cdk8s/issues/1280