### PR TITLE
chore: manually upgrade @cdk8s/projen-common

### DIFF
--- a/.github/workflows/upgrade-configuration.yml
+++ b/.github/workflows/upgrade-configuration.yml
@@ -4,7 +4,7 @@ name: upgrade-configuration
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 15 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-dev-dependencies.yml
+++ b/.github/workflows/upgrade-dev-dependencies.yml
@@ -4,7 +4,7 @@ name: upgrade-dev-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 9 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/.github/workflows/upgrade-runtime-dependencies.yml
+++ b/.github/workflows/upgrade-runtime-dependencies.yml
@@ -4,7 +4,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -209,19 +209,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen,@cdk8s/projen-common'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen,@cdk8s/projen-common'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen,@cdk8s/projen-common'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/jest @types/node cdk8s cdk8s-cli cdk8s-plus-25 cdk8s-plus-26 cdk8s-plus-27 constructs jest jest-junit lerna npm-check-updates semver ts-jest typescript"
+          "exec": "yarn upgrade"
         },
         {
           "exec": "npx projen"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "organization": false
   },
   "devDependencies": {
-    "@cdk8s/projen-common": "^0.0.415",
+    "@cdk8s/projen-common": "^0.0.442",
     "@types/jest": "^26.0.24",
     "@types/node": "^14.18.54",
     "cdk8s": "^2.44.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,12 +290,12 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cdk8s/projen-common@^0.0.415":
-  version "0.0.415"
-  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.415.tgz#dd11c6b2f6104a2515caa31f9e48a283218b6d00"
-  integrity sha512-cBd/Ieqlndp4lLWHzzLfywB6S126kZVXffcPSqqSG50OGg0eQkqPrXtXAQoft8jQlTjdBWrBPjdx152OGLPHTA==
+"@cdk8s/projen-common@^0.0.442":
+  version "0.0.442"
+  resolved "https://registry.yarnpkg.com/@cdk8s/projen-common/-/projen-common-0.0.442.tgz#fbaf05f5093ef8ee59fadb97c2947e7997211e0b"
+  integrity sha512-auetAf6sqdxR+OiS/38eIKtMODp92z0FmNb0aR81woAF7m20f1KRoeDbuJXTu++mt17h/8taqtjMSz+p1aeyXg==
   dependencies:
-    codemaker "^1.85.0"
+    codemaker "^1.87.0"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -2093,15 +2093,6 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
-
-codemaker@^1.85.0:
-  version "1.86.1"
-  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.86.1.tgz#2e34bdab7201ac712532bccba61b8d571348417d"
-  integrity sha512-W35+XgDv/ZNxWTFsvy7xf8XSIwZ8zkJUOlVq0zoOBiZCjk4j0n7HEWy25rI83OZj76ndmyL7EhTyLSTw1PzobA==
-  dependencies:
-    camelcase "^6.3.0"
-    decamelize "^5.0.1"
-    fs-extra "^10.1.0"
 
 codemaker@^1.87.0:
   version "1.87.0"


### PR DESCRIPTION
There was a bug in @cdk8s/projen-common which broke the config upgrade workflow. This requires a manual upgrade to get it working again.

Signed-off-by: Cory Hall <43035978+corymhall@users.noreply.github.com>