### PR TITLE
chore(website): resolver docs touchups

### DIFF
--- a/docs/basics/app.md
+++ b/docs/basics/app.md
@@ -35,12 +35,12 @@ app.synth();
 
 Resolvers are a mechanism to inject custom logic into the cdk8s value resolution process. 
 It allows to transform any value just before being written to the Kubernetes manifest. To define a 
-custom resolver, first create a class that implements the `IValueResolver` interface:
+custom resolver, first create a class that implements the `IResolver` interface:
 
 ```ts
 import { IResolver, ResolutionContext } from 'cdk8s';
 
-export class MyCustomResolver implements IValueResolver {
+export class MyCustomResolver implements IResolver {
 
   public resolve(context: ResolutionContext): any {
     const newValue = ... // run some custom logic


### PR DESCRIPTION
- Resolver interface name was wrong. Left over from its previous name
- Replace the example resolver with a slightly more realistic one
- Remove explanation about invocation patterns, its kind of overwhelming and un-necessary now that the example contains a real implementation