### PR TITLE
fix(website): wrong getting started link

### DIFF
--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -10,7 +10,7 @@
 
 {{- $docs_root := "docs/latest" }}
 
-{{- $link_getting_started := (print $docs_root "/getting-started") }}
+{{- $link_getting_started := (print $docs_root "/get-started") }}
 {{- $link_plus_docs := (print $docs_root "/plus") }}
 {{- $link_concepts := (print $docs_root "/basics") }}
 {{- $link_examples := (print $docs_root "/examples") }}


### PR DESCRIPTION
Following https://github.com/cdk8s-team/cdk8s/pull/1285, the directory was renamed. 

See https://cdk8s.io/docs/latest/get-started/