### PR TITLE
fix(workflows): invalid labels in `bump-latest-cdk8s-plus-library`

### DIFF
--- a/.github/workflows/bump-latest-cdk8s-plus-library.yml
+++ b/.github/workflows/bump-latest-cdk8s-plus-library.yml
@@ -167,8 +167,7 @@ jobs:
           github_token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           title: "chore: set default branch of cdk8s-plus repo to latest for v${{ needs.check-latest-k8s-release.outputs.latestVersion }} k8s upgrade"
           body: The default branch must be manually set to k8s-${{ needs.check-latest-k8s-release.outputs.latestVersion }}/main
-          labels:
-            - priority/p0
+          labels: priority/p0
   update-cdk8s-website:
     needs:
       - check-latest-k8s-release

--- a/src/k8s-automation.ts
+++ b/src/k8s-automation.ts
@@ -250,9 +250,7 @@ export class K8sVersionUpgradeAutomation extends Component {
             github_token: '${{ secrets.PROJEN_GITHUB_TOKEN }}',
             title: 'chore: set default branch of cdk8s-plus repo to latest for v${{ needs.check-latest-k8s-release.outputs.latestVersion }} k8s upgrade',
             body: 'The default branch must be manually set to k8s-${{ needs.check-latest-k8s-release.outputs.latestVersion }}/main',
-            labels: [
-              'priority/p0',
-            ],
+            labels: 'priority/p0',
           },
         },
       ],


### PR DESCRIPTION
The `bump-latest-cdk8s-plus-library` workflow is [failing](https://github.com/cdk8s-team/cdk8s/actions/runs/6562478240):

```console
[Invalid workflow file: .github/workflows/bump-latest-cdk8s-plus-library.yml#L171](https://github.com/cdk8s-team/cdk8s/actions/runs/6562478240/workflow)
The workflow is not valid. .github/workflows/bump-latest-cdk8s-plus-library.yml (Line: 171, Col: 13): A sequence was not expected
```

Fix label definition according to action [documentation](https://github.com/actions-ecosystem/action-create-issue).

> The labels which are added to the created issue when it's created. Must be separated with line breaks if there're multiple labels.