### PR TITLE
fix(workflows): npm status code check for k8s upgrade automation

### DIFF
--- a/.github/workflows/bump-latest-cdk8s-plus-library.yml
+++ b/.github/workflows/bump-latest-cdk8s-plus-library.yml
@@ -45,7 +45,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: needs.check-latest-k8s-release.outputs.httpStatus == 200
+    if: needs.check-latest-k8s-release.outputs.httpStatus != 200
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -102,7 +102,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: needs.check-latest-k8s-release.outputs.httpStatus == 200
+    if: needs.check-latest-k8s-release.outputs.httpStatus != 200
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -176,7 +176,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: needs.check-latest-k8s-release.outputs.httpStatus == 200
+    if: needs.check-latest-k8s-release.outputs.httpStatus != 200
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/k8s-automation.ts
+++ b/src/k8s-automation.ts
@@ -102,7 +102,7 @@ export class K8sVersionUpgradeAutomation extends Component {
         pullRequests: workflows.JobPermission.WRITE,
       },
       needs: ['check-latest-k8s-release'],
-      if: 'needs.check-latest-k8s-release.outputs.httpStatus == 200',
+      if: 'needs.check-latest-k8s-release.outputs.httpStatus != 200',
       steps: [
         {
           name: 'Checkout',
@@ -153,7 +153,7 @@ export class K8sVersionUpgradeAutomation extends Component {
         pullRequests: workflows.JobPermission.WRITE,
       },
       needs: ['check-latest-k8s-release'],
-      if: 'needs.check-latest-k8s-release.outputs.httpStatus == 200',
+      if: 'needs.check-latest-k8s-release.outputs.httpStatus != 200',
       steps: [
         {
           name: 'Checkout',
@@ -268,7 +268,7 @@ export class K8sVersionUpgradeAutomation extends Component {
       },
       // add the cdk8s-plus update job to needs when it's done:
       needs: ['check-latest-k8s-release', 'create-new-plus-branch'],
-      if: 'needs.check-latest-k8s-release.outputs.httpStatus == 200',
+      if: 'needs.check-latest-k8s-release.outputs.httpStatus != 200',
       steps: [
         {
           name: 'Checkout',


### PR DESCRIPTION
Part of #1428 

The npm status code check should verify that the latest version is not published (`status code != 200` - if was originally set to `status code == 200` while testing the workflow)