### PR TITLE
fix(website): cdk8s-plus dropdown shows incorrect spec numbers

### DIFF
--- a/website/build.sh
+++ b/website/build.sh
@@ -12,6 +12,9 @@ export CDK8S_CORE_VERSION="$(get_version cdk8s)"
 export CDK8S_PLUSXX_MINUS_2_VERSION="$(get_version cdk8s-plus-$((${LATEST_K8S_VERSION}-2)))"
 export CDK8S_PLUSXX_MINUS_1_VERSION="$(get_version cdk8s-plus-$((${LATEST_K8S_VERSION}-1)))"
 export CDK8S_PLUSXX_VERSION="$(get_version cdk8s-plus-${LATEST_K8S_VERSION})"
+export CDK8S_PLUSXX_MINUS_2="$((${LATEST_K8S_VERSION}-2))"
+export CDK8S_PLUSXX_MINUS_1="$((${LATEST_K8S_VERSION}-1))"
+export CDK8S_PLUSXX="${LATEST_K8S_VERSION}"
 export CDK8S_CLI_VERSION="$(get_version cdk8s-cli)"
 
 hugo --minify $@

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -2,6 +2,9 @@
 {{- $cdk8s_plusXX_MINUS_2_version := getenv "CDK8S_PLUSXX_MINUS_2_VERSION" }}
 {{- $cdk8s_plusXX_MINUS_1_version := getenv "CDK8S_PLUSXX_MINUS_1_VERSION" }}
 {{- $cdk8s_plusXX_version := getenv "CDK8S_PLUSXX_VERSION" }}
+{{- $cdk8s_plusXX_MINUS_2 := getenv "CDK8S_PLUSXX_MINUS_2" }}
+{{- $cdk8s_plusXX_MINUS_1 := getenv "CDK8S_PLUSXX_MINUS_1" }}
+{{- $cdk8s_plusXX := getenv "CDK8S_PLUSXX" }}
 {{- $cdk8s_cli_version := getenv "CDK8S_CLI_VERSION" }}
 
 {{- $summary := .Site.Params.summary }}
@@ -26,9 +29,9 @@
 {{- $link_terms := "https://aws.amazon.com/terms/?nc1=f_pr" }}
 
 {{- $link_cdk8s_ref := (print $docs_root "/reference/cdk8s/typescript") }}
-{{- $link_plusXX_minus2_ref := (print $docs_root "/reference/cdk8s-plus-" $cdk8s_plusXX_MINUS_2_version "/typescript") }}
-{{- $link_plusXX_minus1_ref := (print $docs_root "/reference/cdk8s-plus-" $cdk8s_plusXX_MINUS_1_version "/typescript") }}
-{{- $link_plusXX_ref := (print $docs_root "/reference/cdk8s-plus-" $cdk8s_plusXX_version "/typescript") }}
+{{- $link_plusXX_minus2_ref := (print $docs_root "/reference/cdk8s-plus-" $cdk8s_plusXX_MINUS_2 "/typescript") }}
+{{- $link_plusXX_minus1_ref := (print $docs_root "/reference/cdk8s-plus-" $cdk8s_plusXX_MINUS_1 "/typescript") }}
+{{- $link_plusXX_ref := (print $docs_root "/reference/cdk8s-plus-" $cdk8s_plusXX "/typescript") }}
 {{- $link_cli := (print $docs_root "/cli") }}
 
 {{- $everywhere := .Site.Params.features.everywhere }}


### PR DESCRIPTION
The dropdown shows the version of the package instead of the spec number:

<img width="265" alt="Screenshot 2024-02-28 at 20 37 08" src="https://github.com/cdk8s-team/cdk8s/assets/1428812/c56625fc-747e-4402-8bef-080daaf5ff82">
