### PR TITLE
fix(website): cdk8s-plus dropdown shows version numbers instead of spec numbers

### DIFF
--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -124,9 +124,9 @@
                         </div>
                         <nav class="dropdown-list w-dropdown-list">
                             <a href="{{ $link_cdk8s_ref }}" class="dropdown-link w-dropdown-link">cdk8s  ({{ $cdk8s_core_version }})</a>
-                            <a href="{{ $link_plusXX_minus2_ref }}" class="dropdown-link w-dropdown-link">cdk8s-plus-{{ $cdk8s_plusXX_MINUS_2_version }}  ({{ $cdk8s_plusXX_MINUS_2_version }})</a>
-                            <a href="{{ $link_plusXX_minus1_ref }}" class="dropdown-link w-dropdown-link">cdk8s-plus-{{ $cdk8s_plusXX_MINUS_1_version }}  ({{ $cdk8s_plusXX_MINUS_1_version }})</a>
-                            <a href="{{ $link_plusXX_ref }}" class="dropdown-link w-dropdown-link">cdk8s-plus-{{ $cdk8s_plusXX_version }} ({{ $cdk8s_plusXX_version }})</a>
+                            <a href="{{ $link_plusXX_minus2_ref }}" class="dropdown-link w-dropdown-link">cdk8s-plus-{{ $cdk8s_plusXX_MINUS_2 }}  ({{ $cdk8s_plusXX_MINUS_2_version }})</a>
+                            <a href="{{ $link_plusXX_minus1_ref }}" class="dropdown-link w-dropdown-link">cdk8s-plus-{{ $cdk8s_plusXX_MINUS_1 }}  ({{ $cdk8s_plusXX_MINUS_1_version }})</a>
+                            <a href="{{ $link_plusXX_ref }}" class="dropdown-link w-dropdown-link">cdk8s-plus-{{ $cdk8s_plusXX }} ({{ $cdk8s_plusXX_version }})</a>
                             <a href="{{ $link_cli }}" target="_blank" class="dropdown-link w-dropdown-link">cdk8s-cli ({{ $cdk8s_cli_version }})<a>
                         </nav>
                     </div>


### PR DESCRIPTION
Follow up to https://github.com/cdk8s-team/cdk8s/pull/1839, which only fixed the links themselves, but not the anchor label.