### PR TITLE
fix(website): links to cdk8s-core api references are broken

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,21 +4,21 @@ This section includes API reference for the various components of cdk8s.
 
 === "TypeScript"
 
-    * [**cdk8s**](/cdk8s/typescript.md)
+    * [**cdk8s**](./cdk8s/typescript.md)
     * [**cdk8s-plus-27**](./cdk8s-plus-27/typescript.md) · Kubernetes v1.27.0
     * [**cdk8s-plus-28**](./cdk8s-plus-28/typescript.md) · Kubernetes v1.28.0
     * [**cdk8s-plus-29**](./cdk8s-plus-29/typescript.md) · Kubernetes v1.29.0
 
 === "Python"
 
-    * [**cdk8s**](/cdk8s/python.md)
+    * [**cdk8s**](./cdk8s/python.md)
     * [**cdk8s-plus-27**](./cdk8s-plus-27/python.md) · Kubernetes v1.27.0
     * [**cdk8s-plus-28**](./cdk8s-plus-28/python.md) · Kubernetes v1.28.0
     * [**cdk8s-plus-29**](./cdk8s-plus-29/python.md) · Kubernetes v1.29.0
 
 === "Java"
 
-    * [**cdk8s**](/cdk8s/java.md)
+    * [**cdk8s**](./cdk8s/java.md)
     * [**cdk8s-plus-27**](./cdk8s-plus-27/java.md) · Kubernetes v1.27.0
     * [**cdk8s-plus-28**](./cdk8s-plus-28/java.md) · Kubernetes v1.28.0
     * [**cdk8s-plus-29**](./cdk8s-plus-29/java.md) · Kubernetes v1.29.0

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -25,7 +25,7 @@ This section includes API reference for the various components of cdk8s.
 
 === "Go"
 
-    * [**cdk8s**](/cdk8s/go.md)
+    * [**cdk8s**](./cdk8s/go.md)
     * [**cdk8s-plus-27**](./cdk8s-plus-27/go.md) · Kubernetes v1.27.0
     * [**cdk8s-plus-28**](./cdk8s-plus-28/go.md) · Kubernetes v1.28.0
     * [**cdk8s-plus-29**](./cdk8s-plus-29/go.md) · Kubernetes v1.29.0


### PR DESCRIPTION
They were using absolute paths instead of relative. 

Fixes https://github.com/cdk8s-team/cdk8s/issues/1958