### PR TITLE
Introducing cdk8s Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ contribute to the project. Please consider the following venues (in order):
 - Stack Overflow: [cdk8s](https://stackoverflow.com/questions/tagged/cdk8s)
 - File a [new issue](https://github.com/cdk8s-team/cdk8s/issues/new/choose)
 - Slack: #cdk8s channel in [cdk.dev](https://cdk.dev)
+- [Ask cdk8s Guru](https://gurubase.io/g/cdk8s)
 
 ## Documentation
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [cdk8s Guru](https://gurubase.io/g/cdk8s) to Gurubase. cdk8s Guru uses the data from this repo and data from the [docs](https://cdk8s.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "cdk8s Guru", which highlights that cdk8s now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable cdk8s Guru in Gurubase, just let me know that's totally fine.