### PR TITLE
feat: add docs type for conventional commits

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -27,4 +27,5 @@ jobs:
             feat
             fix
             chore
+            docs
           requireScope: false


### PR DESCRIPTION
Fixes #2476, allows `docs:` type for PRs