### PR TITLE
fix: resolve #2795 — The triage workflow fails (likely for non-contributors)

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
-          github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

fix: resolve #2795 — The triage workflow fails (likely for non-contributors)

## Problem

**Severity**: `Critical` | **File**: `.github/workflows/triage.yml`

The triage workflow is failing due to bad credentials when trying to add issues to the GitHub project. The issue is likely that the workflow is using an outdated or incorrect token for authentication with the actions/add-to-project action.

## Solution

Update the triage.yml workflow to use the correct GitHub token. The workflow should use either secrets.GITHUB_TOKEN (which is automatically provided) or a custom personal access token with appropriate permissions. The project URL should also be verified to ensure it's correct.

## Changes

- `.github/workflows/triage.yml` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced