### PR TITLE
Security: Regular Expression Denial of Service (ReDoS) in replaceRefsInFile

### DIFF
--- a/src/rotate-cdk8s-plus.ts
+++ b/src/rotate-cdk8s-plus.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function replaceRefsInFile(filePath: string, toReplace: string, substitution: string) {
   // references in the docs files for version XX appear in the following ways:
   // cdk8s-plus-XX, cdk8s.plusXX, cdk8splusXX, CDK8s_PLUSXX_VERSION, cdk8s_plusXX_version
@@ -10,7 +14,7 @@ function replaceRefsInFile(filePath: string, toReplace: string, substitution: st
 
   let curFileData = fs.readFileSync(filePath, 'utf-8');
   referencePrefixes.forEach(function (referencePrefix: string) {
-    curFileData = curFileData.replace(new RegExp(referencePrefix + toReplace, 'g'), referencePrefix + substitution);
+    curFileData = curFileData.replace(new RegExp(referencePrefix + escapeRegExp(toReplace), 'g'), referencePrefix + substitution);
     fs.writeFileSync(filePath, curFileData);
   });
 }


### PR DESCRIPTION
## Summary

Security: Regular Expression Denial of Service (ReDoS) in replaceRefsInFile

## Problem

**Severity**: `Medium` | **File**: `src/rotate-cdk8s-plus.ts:L4`

The `replaceRefsInFile` function in `src/rotate-cdk8s-plus.ts` constructs regular expressions dynamically using `new RegExp(referencePrefix + toReplace, 'g')` without escaping special regex characters in the `toReplace` parameter. If an attacker can control the `toReplace` value (which comes from version numbers derived from user input via `process.argv`), they could inject regex patterns that cause catastrophic backtracking, leading to ReDoS. Additionally, the `referencePrefixes` array contains strings like `plus-` where the hyphen could be interpreted as a regex range operator in certain contexts, though the main risk is from unescaped user input in the substitution pattern.

## Solution

Escape special regex characters in `toReplace` before constructing the RegExp. Use a utility function like: `function escapeRegExp(string) { return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }` and then use `new RegExp(referencePrefix + escapeRegExp(toReplace), 'g')`.

## Changes

- `src/rotate-cdk8s-plus.ts` (modified)